### PR TITLE
fix: sibling keys in message envelope caused serde to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Detailed implementation checklist: `CLAUDE.MD` (see **Implementation Phases**).
 - [x] **Data-loss risk on connect/sync**: plugin currently removes all scene objects during connect/full-state sync instead of only Meerkat-managed objects (`blender_plugin/operators.py`, `blender_plugin/event_handlers.py`).
 - [x] **User identity mismatch edge case**: local `user_id` inferred by matching `display_name`; duplicate names can break echo suppression (`blender_plugin/event_handlers.py`).
 - [x] **Reconnect errors are swallowed**: broad `except Exception: pass` hides failures and complicates debugging (`blender_plugin/websocket_client.py`).
-- [ ] **Blender version gate too strict**: addon currently declares Blender `5.0.0` minimum (`blender_plugin/__init__.py`).
-- [ ] **High-volume debug printing**: per-event payload printing adds overhead in active sessions (`blender_plugin/event_handlers.py`).
+- [x] **Blender version gate too strict**: addon currently declares Blender `5.0.0` minimum (`blender_plugin/__init__.py`).
+- [x] **High-volume debug printing**: per-event payload printing adds overhead in active sessions (`blender_plugin/event_handlers.py`).
 
 ### What Meerkat already covers in Blender
 
@@ -101,6 +101,11 @@ Detailed implementation checklist: `CLAUDE.MD` (see **Implementation Phases**).
 - [x] Presence features: connected users, selected-object highlights, and remote cursor overlays.
 - [x] Shared asset library placement with hierarchy support and missing-asset placeholders.
 - [x] Full state sync + reconnect foundation + save-scene workflow.
+
+More Issues: 
+Purposeful disconnect triggers retry logic 
+stuck in the reconnecting state too 
+users dont join the same session  
 
 ### High-impact additions for the ecosystem
 
@@ -120,15 +125,6 @@ Detailed implementation checklist: `CLAUDE.MD` (see **Implementation Phases**).
 - [ ] Enforce guardrails: message rate limits, payload size limits, max users/session, max active sessions, idle TTL.
 - [ ] Replace panic paths with recoverable errors and server-side error events.
 - [ ] Add production metrics: active sessions/connections, queue depth, drop counts, latency percentiles, msg/sec.
-
-
-
-### First improvement set (next branch scope)
-
-- [ ] Backend reliability hardening:
-  1) Backpressure policy with coalescing for high-rate updates.
-  2) No-drop handling for critical events (create/delete/join/leave).
-  3) Remove panic-prone `expect` paths from runtime message flow.
 
 ---
 

--- a/backend/meerkat-server/src/messages.rs
+++ b/backend/meerkat-server/src/messages.rs
@@ -174,7 +174,16 @@ pub enum ServerEvent {
 
 /// Deserializes a raw JSON string into a ClientEvent.
 pub fn parse_client_message(raw: &str) -> Result<ClientEvent, serde_json::Error> {
-    serde_json::from_str(raw)
+    // Step 1: parse the wrapper (handles the extra timestamp/source_user_id fields)
+    let envelope: MessageEnvelope = serde_json::from_str(raw)?;
+
+    // Step 2: reconstruct a clean {event_type, payload} object for the tagged enum
+    let event_json = serde_json::json!({
+        "event_type": envelope.event_type,
+        "payload": envelope.payload,
+    });
+
+    serde_json::from_value(event_json)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/backend/meerkat-server/src/websocket.rs
+++ b/backend/meerkat-server/src/websocket.rs
@@ -41,12 +41,17 @@ pub async fn handle_connection(mut socket: WebSocket, state: AppState) {
                 match msg {
                     Some(Ok(Message::Text(t))) => {
                         let text = t.to_string();
+                        tracing::info!(connection_id = %connection_id, raw_message = %text, "received client message");
                         match parse_client_message(&text) {
-                            Ok(event) => dispatch(&mut socket, &state, connection_id, event).await,
+                            Ok(event) => {
+                                tracing::info!(connection_id = %connection_id, event_type = ?event, "parsed client event");
+                                dispatch(&mut socket, &state, connection_id, event).await
+                            },
                             Err(e) => {
                                 tracing::warn!(
                                     connection_id = %connection_id,
                                     error = %e,
+                                    raw_message = %text,
                                     "failed to parse client message"
                                 );
                             }
@@ -57,7 +62,7 @@ pub async fn handle_connection(mut socket: WebSocket, state: AppState) {
                     Some(Err(_)) => break,
                     None => { 
                         // This none case means the server cant read client messages 
-                        break; 
+                        break;
                     }
                 }
             }

--- a/blender_plugin/.gitignore
+++ b/blender_plugin/.gitignore
@@ -1,0 +1,11 @@
+# Ignore Python cache files
+__pycache__/
+*.py[cod]
+# Ignore Blender temp files
+*.blend1
+*.blend2
+# Ignore VSCode settings
+.vscode/
+# Ignore OS files
+.DS_Store
+Thumbs.db

--- a/blender_plugin/event_handlers.py
+++ b/blender_plugin/event_handlers.py
@@ -175,6 +175,8 @@ def handle_full_state_sync(payload):
     state.is_applying_remote_update = True
 
     try:
+        # set id 
+        state.user_id = payload.get("your_user_id", "")
         # 1. Delete all existing Meerkat-managed objects from the scene
         objs_to_remove = list(bpy.data.objects)
         for obj in objs_to_remove:
@@ -190,9 +192,6 @@ def handle_full_state_sync(payload):
         objects = session.get("objects", {})
         for obj_id, obj_data in objects.items():
             _create_object_from_snapshot(obj_id, obj_data)
-
-        # set user id
-        state.user_id = payload.get("your_user_id", "")
 
         # 3. Rebuild user list using user ids from session snapshot
         state.users.clear()

--- a/blender_plugin/operators.py
+++ b/blender_plugin/operators.py
@@ -76,13 +76,15 @@ class MEERKAT_OT_connect(bpy.types.Operator):
         state.connected = True
         state.evicted = False
 
-        client.send({
+        join_msg = {
             "event_type": "JoinSession",
             "payload": {
                 "session_id": room_name,
                 "display_name": display_name,
             }
-        })
+        }
+        print("[Meerkat DEBUG] Sending JoinSession:", join_msg)
+        client.send(join_msg)
 
         # Start the cursor tracker modal
         bpy.ops.meerkat.cursor_tracker('INVOKE_DEFAULT')

--- a/blender_plugin/panels.py
+++ b/blender_plugin/panels.py
@@ -4,11 +4,8 @@ from .state import PluginState
 
 def _connection_status_lines(state):
     lines = []
-    if state.reconnecting:
-        if state.evicted:
-            lines.append(("Disconnected by server (lag)", 'ERROR'))
-        lines.append((f"Reconnecting ({state.reconnect_attempt}/{3})...", 'TIME'))
-    elif not state.connected and state.evicted:
+    # Reconnect UI removed: no retry logic in client as of 2026-04-13.
+    if not state.connected and state.evicted:
         lines.append(("Connection closed: client fell behind", 'ERROR'))
     return lines
 
@@ -27,9 +24,8 @@ class MEERKAT_PT_main_panel(bpy.types.Panel):
         for text, icon in _connection_status_lines(state):
             layout.label(text=text, icon=icon)
 
-        if state.reconnecting:
-            pass
-        elif not state.connected:
+        # Reconnect UI removed: no retry logic in client as of 2026-04-13.
+        if not state.connected:
             layout.prop(context.scene, "meerkat_room_name")
             layout.prop(context.scene, "meerkat_display_name")
             layout.operator("meerkat.connect")

--- a/blender_plugin/state.py
+++ b/blender_plugin/state.py
@@ -1,6 +1,8 @@
 # state.py — PluginState singleton
 # Singleton was chosen to ensure that only one instance of eaach class can ever
 # be possible
+from uuid import uuid4
+
 from dataclasses import dataclass, field
 from typing import Optional 
 from .websocket_client import WebSocketClient
@@ -21,7 +23,7 @@ class PluginState(metaclass=Singleton):
     connected: bool = False
     ws_client: WebSocketClient | None = None
     session_id: str = ""
-    user_id: str = ""
+    user_id: str = field(default_factory=lambda: str(uuid4()))
     display_name: str = ""
     object_map: dict = field(default_factory=dict)       # meerkat_id -> bpy.types.Object
     users: dict = field(default_factory=dict)             # user_id -> {display_name, color, selected_object}

--- a/blender_plugin/tests/test_reconnect.py
+++ b/blender_plugin/tests/test_reconnect.py
@@ -2,11 +2,15 @@
 
 Mocks websockets.connect to simulate connection drops and retries,
 then drives _listen() directly via asyncio.run() to verify behavior.
+NOTE: All reconnect tests are currently skipped because reconnect logic is disabled.
+"""
+import pytest
 """
 import asyncio
 import json
 import sys
 import os
+import pytest
 
 plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if plugin_dir not in sys.path:
@@ -182,28 +186,24 @@ def test_initial_connect_no_join_from_listen(result):
     finally:
         _unpatch()
 
-
 def test_reconnect_sends_join_session(result):
+        @pytest.mark.skip(reason=RECONNECT_SKIP_REASON)
     """On reconnect, _listen sends exactly one JoinSession."""
     import pytest
-    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
-    name = "reconnect sends JoinSession"
     state = _reset_state()
+        @pytest.mark.skip(reason=RECONNECT_SKIP_REASON)
 
     # first connection drops immediately, second stays alive briefly
-    ws1 = MockWS(drop_after=0)
-    ws2 = MockWS(drop_after=1)
     mock_connect = MockConnectContext([ws1, ws2])
+        @pytest.mark.skip(reason=RECONNECT_SKIP_REASON)
     client = _make_client()
     _patch(client, mock_connect)
-
-    _sleep_delays.clear()
     original_sleep = asyncio.sleep
+        @pytest.mark.skip(reason=RECONNECT_SKIP_REASON)
 
     async def drive():
-        # patch sleep inside the coroutine
-        import blender_plugin.websocket_client as ws_mod
         original_asyncio = asyncio
+        @pytest.mark.skip(reason=RECONNECT_SKIP_REASON)
 
         async def fast_sleep(delay):
             _sleep_delays.append(delay)
@@ -250,7 +250,7 @@ def test_reconnect_sends_join_session(result):
 def test_reconnect_delays_are_3_9_27(result):
     """Retry delays follow RECONNECT_DELAYS = [3, 9, 27]."""
     import pytest
-    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
+    pytest.skip("Reconnect logic is currently disabled; see issue #XXX")
     name = "reconnect delays are 3, 9, 27"
     state = _reset_state()
 
@@ -335,7 +335,7 @@ def test_intentional_disconnect_skips_retry(result):
 def test_all_retries_exhausted(result):
     """After 3 failed retries, state.connected = False and state.reconnecting = False."""
     import pytest
-    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
+    pytest.skip("Reconnect logic is currently disabled; see issue #XXX")
     name = "all retries exhausted sets connected=False"
     state = _reset_state()
 
@@ -382,7 +382,7 @@ def test_all_retries_exhausted(result):
 def test_reconnect_resets_retry_index(result):
     """After a successful reconnect, retry_index resets so future drops get fresh retries."""
     import pytest
-    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
+    pytest.skip("Reconnect logic is currently disabled; see issue #XXX")
     name = "successful reconnect resets retry index"
     state = _reset_state()
 
@@ -432,7 +432,7 @@ def test_reconnect_resets_retry_index(result):
 def test_reconnect_only_one_join_per_reconnect(result):
     """Each successful reconnect sends exactly one JoinSession, not duplicates."""
     import pytest
-    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
+    pytest.skip("Reconnect logic is currently disabled; see issue #XXX")
     name = "only one JoinSession per reconnect"
     state = _reset_state()
 

--- a/blender_plugin/tests/test_reconnect.py
+++ b/blender_plugin/tests/test_reconnect.py
@@ -185,6 +185,8 @@ def test_initial_connect_no_join_from_listen(result):
 
 def test_reconnect_sends_join_session(result):
     """On reconnect, _listen sends exactly one JoinSession."""
+    import pytest
+    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
     name = "reconnect sends JoinSession"
     state = _reset_state()
 
@@ -247,6 +249,8 @@ def test_reconnect_sends_join_session(result):
 
 def test_reconnect_delays_are_3_9_27(result):
     """Retry delays follow RECONNECT_DELAYS = [3, 9, 27]."""
+    import pytest
+    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
     name = "reconnect delays are 3, 9, 27"
     state = _reset_state()
 
@@ -330,6 +334,8 @@ def test_intentional_disconnect_skips_retry(result):
 
 def test_all_retries_exhausted(result):
     """After 3 failed retries, state.connected = False and state.reconnecting = False."""
+    import pytest
+    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
     name = "all retries exhausted sets connected=False"
     state = _reset_state()
 
@@ -375,6 +381,8 @@ def test_all_retries_exhausted(result):
 
 def test_reconnect_resets_retry_index(result):
     """After a successful reconnect, retry_index resets so future drops get fresh retries."""
+    import pytest
+    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
     name = "successful reconnect resets retry index"
     state = _reset_state()
 
@@ -423,6 +431,8 @@ def test_reconnect_resets_retry_index(result):
 
 def test_reconnect_only_one_join_per_reconnect(result):
     """Each successful reconnect sends exactly one JoinSession, not duplicates."""
+    import pytest
+    pytest.skip("Reconnect logic is currently disabled; skipping reconnect tests.")
     name = "only one JoinSession per reconnect"
     state = _reset_state()
 

--- a/blender_plugin/websocket_client.py
+++ b/blender_plugin/websocket_client.py
@@ -90,7 +90,7 @@ class WebSocketClient:
             "event_type": message_dict.get("event_type"),
             "timestamp": int(time.time() * 1000),
             "source_user_id": state.user_id,
-            "payload": message_dict.get("payload", {})
+            "payload": message_dict.get("payload")
         }
         data = json.dumps(envelope)
         future = asyncio.run_coroutine_threadsafe(ws.send(data), self.loop)
@@ -136,4 +136,3 @@ class WebSocketClient:
         if ws is not None and not getattr(ws, "open", True):
             return getattr(ws, "close_code", None) == EVICTED_CLOSE_CODE
         return self.last_close_code == EVICTED_CLOSE_CODE
-    

--- a/blender_plugin/websocket_client.py
+++ b/blender_plugin/websocket_client.py
@@ -8,10 +8,10 @@ import threading
 import asyncio
 import json
 import queue
+import time
 import websockets
 
 
-RECONNECT_DELAYS = [3, 9, 27]  # powers of 3, ~39s total
 EVICTED_CLOSE_CODE = 4008
 
 
@@ -50,104 +50,90 @@ class WebSocketClient:
     async def _listen(self):
         from .state import PluginState
         state = PluginState()
-        retry_index = 0
-        is_first_connect = True
 
-        while self.running:
-            try:
-                async with websockets.connect(self.url) as ws:
-                    self.ws = ws
-                    self.last_close_code = None
-                    self.last_close_reason = ""
-                    self.connected_event.set()
-                    state.connected = True
-                    state.evicted = False
-                    state.reconnecting = False
-                    state.reconnect_attempt = 0
-                    retry_index = 0  # reset on successful connection
-
-                    # re-send JoinSession only on reconnect (not first connect)
-                    if not is_first_connect and self.session_id and self.display_name:
-                        join_msg = json.dumps({
-                            "event_type": "JoinSession",
-                            "payload": {
-                                "session_id": self.session_id,
-                                "display_name": self.display_name,
-                            }
-                        })
-                        await ws.send(join_msg)
-
-                    is_first_connect = False
-
-                    while self.running:
-                        try:
-                            raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
-                            msg = json.loads(raw)
-                            self.incoming.put(msg)
-                        except asyncio.TimeoutError:
-                            continue
-                        except websockets.ConnectionClosed as e:
-                            self.last_close_code = e.code
-                            self.last_close_reason = e.reason or ""
-                            state.evicted = (e.code == EVICTED_CLOSE_CODE)
-                            state.connected = False
-                            state.reconnecting = True
-                            state.reconnect_attempt = 0
-                            self.ws = None
-                            break
-
-            except Exception as e:
-                state.connected = False
-                self.ws = None
-                print(f"[Meerkat] WebSocket listen/connect error: {type(e).__name__}: {e}")
-                pass  # fall through to retry logic below
-
-            # --- Retry logic ---
-            if not self.running or state.intentional_disconnect:
-                break
-
-            if retry_index >= len(RECONNECT_DELAYS):
-                print("[Meerkat] Reconnect failed after all attempts.")
+        try:
+            async with websockets.connect(self.url) as ws:
+                self.ws = ws
+                self.connected_event.set()
+                state.connected = True
+                state.evicted = False
                 state.reconnecting = False
                 state.reconnect_attempt = 0
-                state.connected = False
-                break
 
-            delay = RECONNECT_DELAYS[retry_index]
-            retry_index += 1
-            state.reconnecting = True
-            state.reconnect_attempt = retry_index
-            print(f"[Meerkat] Connection lost. Reconnecting ({retry_index}/{len(RECONNECT_DELAYS)}) in {delay}s...")
-
-            try:
-                await asyncio.sleep(delay)
-            except asyncio.CancelledError:
-                break
-
-            if not self.running or state.intentional_disconnect:
-                break
-
-            # loop back to the top -> websockets.connect() again
+                while self.running:
+                    try:
+                        raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+                        msg = json.loads(raw)
+                        self.incoming.put(msg)
+                    except asyncio.TimeoutError:
+                        continue
+                    except websockets.ConnectionClosed as e:
+                        self.last_close_code = e.code
+                        self.last_close_reason = e.reason or ""
+                        state.evicted = (e.code == EVICTED_CLOSE_CODE)
+                        state.connected = False
+                        break
+        except Exception as e:
+            state.connected = False
+            print(f"[Meerkat] WebSocket error: {type(e).__name__}: {e}")
 
         self.ws = None
         self.running = False
 
     def send(self, message_dict):
+        from .state import PluginState
+        state = PluginState()
         ws = self.ws
-        if ws and self.loop and self.running and not ws.closed:
-            data = json.dumps(message_dict)
-            asyncio.run_coroutine_threadsafe(ws.send(data), self.loop)
+        if not ws or not self.loop or not self.running:
+            return
+        envelope = {
+            "event_type": message_dict.get("event_type"),
+            "timestamp": int(time.time() * 1000),
+            "source_user_id": state.user_id,
+            "payload": message_dict.get("payload", {})
+        }
+        data = json.dumps(envelope)
+        future = asyncio.run_coroutine_threadsafe(ws.send(data), self.loop)
+        future.add_done_callback(self._on_send_done)
+
+
+    def _on_send_done(self, future):    
+        try:
+            future.result()
+        except Exception as e:  
+            print(f"[Meerkat] Error sending message: {type(e).__name__}: {e}")
 
     def disconnect(self):
+        from .state import PluginState
+        state = PluginState()
+        state.intentional_disconnect = True
         self.running = False
         if self.ws and self.loop:
-            asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
+            future = asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
+            future.add_done_callback(self._on_disconnect_done)
+        else:
+            self._clear_connection_state()
+
+    def _on_disconnect_done(self, future):
+        try:
+            future.result()
+        except Exception as e:
+            print(f"[Meerkat] Error closing WebSocket: {type(e).__name__}: {e}")
+        self._clear_connection_state()
+
+    def _clear_connection_state(self):
+        from .state import PluginState
+        state = PluginState()
         self.ws = None
         self.last_close_code = None
         self.last_close_reason = ""
+        state.reconnecting = False
+        state.reconnect_attempt = 0
 
     def is_evicted(self):
         ws = self.ws
-        if ws is not None and ws.closed:
-            return ws.close_code == EVICTED_CLOSE_CODE
+        # websockets 16.x: use ws.open to check if connection is open
+        if ws is not None and not getattr(ws, "open", True):
+            return getattr(ws, "close_code", None) == EVICTED_CLOSE_CODE
         return self.last_close_code == EVICTED_CLOSE_CODE
+    


### PR DESCRIPTION
fix: sibling keys in message envelope caused serde to fail
removed: retry logic for now

fixes issue #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated reliability checklist and added a new "More Issues" notes section.

* **Improvements**
  * Session participants now receive unique auto-generated IDs.
  * Outgoing messages include richer metadata for tracking.
  * Connection state handling and disconnect flow improved; eviction detection refined.
  * UI now shows connect controls consistently when disconnected.

* **Changes**
  * Automatic reconnect/retry loop simplified/removed.

* **Tests**
  * Reconnect-related tests marked to be skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->